### PR TITLE
fix: use \A and \z for string delimiters

### DIFF
--- a/parts.go
+++ b/parts.go
@@ -60,7 +60,7 @@ func (pl partList) generateRegularExpressionAndNameList(options options) (string
 		result.WriteString("(?i)")
 	}
 
-	result.WriteByte('^')
+	result.WriteString("\\A(?:")
 
 	for _, p := range pl {
 		if p.pType == partFixedText {
@@ -165,7 +165,7 @@ func (pl partList) generateRegularExpressionAndNameList(options options) (string
 		}
 	}
 
-	result.WriteByte('$')
+	result.WriteString(")\\z")
 
 	return result.String(), nameList, nil
 }


### PR DESCRIPTION
See https://stackoverflow.com/a/5979643/1352334 and https://www.ietf.org/rfc/rfc9485.html#section-5.4.