### PR TITLE
test: add benchmark suite for New/Test/Exec

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,86 @@
+package urlpattern_test
+
+import (
+	"testing"
+
+	"github.com/dunglas/go-urlpattern"
+)
+
+var benchmarkPatterns = []struct {
+	name, pattern, baseURL string
+}{
+	{"simple", "https://example.com/foo/bar", ""},
+	{"wildcard", "https://*.example.com/*", ""},
+	{"named", "https://example.com/users/:id/posts/:postId", ""},
+	{"regex", "https://example.com/items/(\\d+)", ""},
+	{"full", "https://user:pw@example.com:8080/path/:id?q=:v#:frag", ""},
+}
+
+var benchmarkMatches = []struct {
+	name, pattern, input string
+}{
+	{"simple", "https://example.com/foo/bar", "https://example.com/foo/bar"},
+	{"wildcard", "https://*.example.com/*", "https://api.example.com/users/42"},
+	{"named", "https://example.com/users/:id/posts/:postId", "https://example.com/users/42/posts/7"},
+	{"regex", "https://example.com/items/(\\d+)", "https://example.com/items/12345"},
+	{"miss", "https://example.com/foo", "https://example.com/bar"},
+}
+
+// Package-level sinks: keep return values live so the compiler cannot
+// dead-code-eliminate the benchmarked calls.
+var (
+	benchPatternSink *urlpattern.URLPattern
+	benchBoolSink    bool
+	benchResultSink  *urlpattern.URLPatternResult
+)
+
+func BenchmarkNew(b *testing.B) {
+	for _, bc := range benchmarkPatterns {
+		b.Run(bc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var p *urlpattern.URLPattern
+			var err error
+			for i := 0; i < b.N; i++ {
+				p, err = urlpattern.New(bc.pattern, bc.baseURL, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			benchPatternSink = p
+		})
+	}
+}
+
+func BenchmarkTest(b *testing.B) {
+	for _, bc := range benchmarkMatches {
+		p, err := urlpattern.New(bc.pattern, "", nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(bc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var ok bool
+			for i := 0; i < b.N; i++ {
+				ok = p.Test(bc.input, "")
+			}
+			benchBoolSink = ok
+		})
+	}
+}
+
+func BenchmarkExec(b *testing.B) {
+	for _, bc := range benchmarkMatches {
+		p, err := urlpattern.New(bc.pattern, "", nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(bc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var r *urlpattern.URLPatternResult
+			for i := 0; i < b.N; i++ {
+				r = p.Exec(bc.input, "")
+			}
+			benchResultSink = r
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add BenchmarkNew, BenchmarkTest, BenchmarkExec covering simple, wildcard, named, regex and full patterns.
- No production code changes — this gives us a baseline so later perf PRs can quote numbers.