### PR TITLE
fix: propagate tokenizing error on trailing backslash

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -51,7 +51,7 @@ func tokenize(input string, policy tokenizePolicy) ([]token, error) {
 
 		case '\\':
 			if t.index == len-1 {
-				if err := t.processTokenizingError(t.nextIndex, t.index); err == nil {
+				if err := t.processTokenizingError(t.nextIndex, t.index); err != nil {
 					return nil, err
 				}
 

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -1,0 +1,34 @@
+package urlpattern_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dunglas/go-urlpattern"
+)
+
+// Regression: a pattern pathname ending with a trailing backslash used to
+// hang the strict tokenizer because the escape-at-end branch swallowed the
+// returned error instead of propagating it, leaving the tokenizer index
+// unchanged and causing an infinite loop.
+func TestTrailingBackslashDoesNotHang(t *testing.T) {
+	pathname := "/foo\\"
+	init := &urlpattern.URLPatternInit{Pathname: &pathname}
+
+	done := make(chan struct{})
+	var newErr error
+	go func() {
+		defer close(done)
+		_, newErr = init.New(nil)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("URLPatternInit.New hung on pathname with trailing backslash")
+	}
+
+	if newErr == nil {
+		t.Fatal("expected an error for a pathname ending with a lone backslash, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
The escape-at-end branch in `tokenize()` checked `err == nil` instead of `err != nil`, which under strict policy dropped the returned error and left the tokenizer's index unchanged — a `URLPatternInit` whose pathname ends in a lone `\` looped forever. Under lenient policy it returned `(nil, nil)` after a single invalid-char token, truncating the rest of the pattern.

Flip the condition and add a regression test that fails with a timeout if strict tokenization hangs.