### PR TITLE
fix: propagate error from canonicalizeHash

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -573,7 +573,7 @@ func canonicalizeHash(value string) (string, error) {
 	dummyURL := urlParser.NewUrl()
 	u, err := urlParser.BasicParser(value, nil, dummyURL, url.StateFragment)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return u.Fragment(), nil


### PR DESCRIPTION
## Summary
`canonicalizeHash` returned `("", nil)` when the URL basic parser failed on the fragment state, silently masking the parse failure and making invalid hashes look like empty canonicalizations. Return the real error instead.