### PR TITLE
fix: canonicalize strippedValue in processHashForInit

### DIFF
--- a/urlpattern.go
+++ b/urlpattern.go
@@ -681,7 +681,7 @@ func processHashForInit(value, hType string) (string, error) {
 		return strippedValue, nil
 	}
 
-	return canonicalizeHash(value)
+	return canonicalizeHash(strippedValue)
 }
 
 // https://urlpattern.spec.whatwg.org/#is-an-absolute-pathname


### PR DESCRIPTION
## Summary
`processHashForInit` computed `strippedValue` (the hash with a leading `#` removed) but then handed the *original* `value` to `canonicalizeHash`. The spec and the sibling search processor both canonicalize the stripped form.