### PR TITLE
spec: conform to latest WHATWG URL Pattern WPT test data

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -27,7 +27,7 @@ var DefaultPorts = map[string]string{
 }
 
 var urlParser = url.NewParser()
-var hostnameParser = canonicalizer.New(url.WithFailOnValidationError(), canonicalizer.WithDefaultScheme("http"))
+var hostnameParser = canonicalizer.New(canonicalizer.WithDefaultScheme("http"))
 
 var (
 	NonEmptySuffixError      = errors.New("suffix must be the empty string")
@@ -424,10 +424,12 @@ func canonicalizeHostname(hostnameValue, protocolValue string) (string, error) {
 		return hostnameValue, nil
 	}
 
-	// Dirty workaround for https://github.com/whatwg/urlpattern/issues/206
-	if hostnameValue[:1] != "[" {
+	// Non-IPv6 hostnames must not contain ':': without this guard, the URL
+	// parser would split "host:port" into host and port, silently accepting
+	// patterns like "bad:hostname" as a plain hostname.
+	if hostnameValue[0] != '[' {
 		for _, c := range hostnameValue {
-			if c == '/' || c == '?' || c == '#' || c == ':' || c == '\\' {
+			if c == ':' {
 				return "", errors.New("invalid hostname")
 			}
 		}
@@ -466,38 +468,41 @@ func canonicalizePort(portValue, protocolValue string) (string, error) {
 		return portValue, nil
 	}
 
-	var (
-		u   *url.Url
-		err error
-	)
-
-	if protocolValue == "" {
-		u = hostnameParser.NewUrl()
-	} else {
-		u, err = hostnameParser.Parse(protocolValue + "://dummy.test")
-		if err != nil {
-			return "", err
+	// The WHATWG port state strips ASCII tab / LF / CR before examining the
+	// first code point, so reject inputs whose first significant byte is not
+	// an ASCII digit (e.g. "invalid80"). Without this the URL library returns
+	// an empty port instead of failing.
+	firstDigit := false
+	for i := 0; i < len(portValue); i++ {
+		c := portValue[i]
+		if c == '\t' || c == '\n' || c == '\r' {
+			continue
 		}
+		firstDigit = c >= '0' && c <= '9'
+		break
+	}
+	if !firstDigit {
+		return "", InvalidPortError
 	}
 
-	u, err = hostnameParser.BasicParser(portValue, nil, u, url.StatePort)
+	scheme := protocolValue
+	if scheme == "" {
+		// Use a non-special scheme so the URL parser does not treat a
+		// well-known default port (http/80, https/443, ...) as empty.
+		scheme = "urlpattern-non-special"
+	}
+
+	u, err := urlParser.Parse(scheme + "://dummy.test")
 	if err != nil {
 		return "", err
 	}
 
-	p := u.Port()
-
-	// This looks like a bug in the spec ("80 " should be considered valid), but there is a test covering this
-	// Another dirty workaround
-	if p != portValue {
-		if dp, ok := DefaultPorts[protocolValue]; ok && portValue == dp {
-			return p, nil
-		}
-
-		return "", InvalidPortError
+	u, err = urlParser.BasicParser(portValue, nil, u, url.StatePort)
+	if err != nil {
+		return "", err
 	}
 
-	return p, nil
+	return u.Port(), nil
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname

--- a/testdata/urlpatterntestdata.json
+++ b/testdata/urlpatterntestdata.json
@@ -1122,6 +1122,63 @@
     }
   },
   {
+    "pattern": ["http://\uD83D\uDEB2.com/"],
+    "inputs": ["http://\uD83D\uDEB2.com/"],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "xn--h78h.com",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}},
+      "hostname": { "input": "xn--h78h.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D \uDEB2"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"hostname":"\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":"\uD83D \uDEB2"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": "%EF%BF%BD%20%EF%BF%BD"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":":\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":":a\uDB40\uDD00b"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": ":a\uDB40\uDD00b"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":"test/:a\uD801\uDC50b"}],
+    "inputs": [{"pathname":"test/foo"}],
+    "expected_obj": {
+      "pathname": "test/:a\uD801\uDC50b"
+    },
+    "expected_match": {
+      "pathname": { "input": "test/foo", "groups": { "a\uD801\uDC50b": "foo" }}
+    }
+  },
+  {
+    "pattern": [{"pathname":":\uD83D\uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
     "pattern": [{ "port": "" }],
     "inputs": [{ "protocol": "http", "port": "80" }],
     "exactly_empty_components": [ "port" ],
@@ -1145,6 +1202,15 @@
   {
     "pattern": [{ "protocol": "http", "port": "80 " }],
     "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_obj": {
+      "protocol": "http",
+      "port": "80"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "100000" }],
+    "inputs": [{ "protocol": "http", "port": "100000" }],
     "expected_obj": "error"
   },
   {
@@ -1160,6 +1226,34 @@
   {
     "pattern": [{ "port": "80" }],
     "inputs": [{ "port": "80" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "8\t0" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80?x" }],
+    "expected_match": {
+      "port": { "input": "80", "groups": {}}
+    }
+  },
+  {
+    "pattern": [{ "port": "80" }],
+    "inputs": [{ "port": "80\\x" }],
     "expected_match": {
       "port": { "input": "80", "groups": {}}
     }
@@ -1809,7 +1903,17 @@
   {
     "pattern": [ "https://{sub.}?example{.com/}foo" ],
     "inputs": [ "https://example.com/foo" ],
-    "expected_obj": "error"
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" } }
+    }
   },
   {
     "pattern": [ "{https://}example.com/foo" ],
@@ -2367,7 +2471,13 @@
   },
   {
     "pattern": [{ "hostname": "bad#hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname":  "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad%hostname" }],
@@ -2375,7 +2485,13 @@
   },
   {
     "pattern": [{ "hostname": "bad/hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\\:hostname" }],
@@ -2407,7 +2523,11 @@
   },
   {
     "pattern": [{ "hostname": "bad\\\\hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": null
   },
   {
     "pattern": [{ "hostname": "bad^hostname" }],
@@ -2419,15 +2539,33 @@
   },
   {
     "pattern": [{ "hostname": "bad\nhostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\rhostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\thostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{}],
@@ -2853,5 +2991,168 @@
     "pattern": [{ "pathname": "/([\\d&&[0-1]])" }],
     "inputs": [{ "pathname": "/3" }],
     "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com/ignoredpath" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com\\?ignoredsearch" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "search": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": [{ "protocol": "http", "hostname": "example.com#ignoredhash" }],
+    "inputs": ["http://example.com/"],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "example.com",
+      "hash": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/", "groups": { "0": "/" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/x", "groups": { "0": "x" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/xyz"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/xyz", "groups": { "0": "xyz" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/example"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/example", "groups": { "0": "example" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/text"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/text", "groups": { "0": "text" } }
+    }
+  },
+  {
+    "pattern": ["https://www.example.com/*"],
+    "inputs": ["https://www.example.com/path/with/x"],
+    "exactly_empty_components": ["port"],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "www.example.com",
+      "pathname": "/*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "www.example.com", "groups": {} },
+      "pathname": { "input": "/path/with/x", "groups": { "0": "path/with/x" } }
+    }
+  },
+  {
+    "pattern": [{ "hostname": ":domain(.*)" }],
+    "inputs": [{ "hostname": "localhost" }],
+    "expected_obj": {
+      "hostname": ":domain(.*)"
+    },
+    "expected_match": {
+      "hostname": { "input": "localhost", "groups": { "domain" : "localhost"} }
+    }
+  },
+  {
+    "pattern": ["((?R)):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": ["(\\H):"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [
+      {"pathname": "/:foo((?<x>a))"}
+    ],
+    "inputs": [
+      {"pathname": "/a"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/a",
+        "groups": {"foo": "a"}
+      }
+    }
+  },
+  {
+    "pattern": [
+      {"pathname": "/foo/(bar(?<x>baz))"}
+    ],
+    "inputs": [
+      {"pathname": "/foo/barbaz"}
+    ],
+    "expected_match": {
+      "pathname": {
+        "input": "/foo/barbaz",
+        "groups": {"0": "barbaz"}
+      }
+    }
   }
 ]

--- a/urlpattern.go
+++ b/urlpattern.go
@@ -390,12 +390,16 @@ func (u *URLPattern) HasRegexpGroups() bool {
 func createComponentMatchResult(component component, input string, execResult []string) URLPatternComponentResult {
 	result := URLPatternComponentResult{Input: input}
 
-	if len(execResult)-1 == 0 || (len(execResult) == 2 && execResult[0] == "" && execResult[1] == "") {
+	if len(component.groupNameList) == 0 || (len(execResult) == 2 && execResult[0] == "" && execResult[1] == "") {
 		return result
 	}
 
-	result.Groups = make(map[string]string, len(execResult)-1)
-	for index := 1; index < len(execResult); index++ {
+	result.Groups = make(map[string]string, len(component.groupNameList))
+	limit := len(execResult)
+	if namedLimit := len(component.groupNameList) + 1; namedLimit < limit {
+		limit = namedLimit
+	}
+	for index := 1; index < limit; index++ {
 		name := component.groupNameList[index-1]
 		value := execResult[index]
 


### PR DESCRIPTION
## Summary
Refresh `testdata/urlpatterntestdata.json` from the current WPT snapshot (365 cases, up from 313) and align the implementation:

- `createComponentMatchResult`: bound iteration by the group name list length so user-provided regex groups (e.g. `:foo((?<x>a))`) no longer index past the name list and panic. Unnamed captures are simply omitted from `Groups`, matching WPT 364.
- `canonicalizeHostname`: drop the broad reject-on-`/?#\` guard — the URL parser now truncates hostnames correctly at those boundaries. The `:` check stays because the parser silently splits `host:port` with no surface-level error.
- `hostnameParser`: drop `WithFailOnValidationError` so tab / LF / CR are stripped per the URL spec instead of errored.
- `canonicalizePort`: rewritten to (1) skip leading tab/LF/CR and require the first significant byte to be a digit (rejects `"invalid80"`), (2) parse against a non-special scheme when no protocol is supplied so default ports are not collapsed to `""`, and (3) drop the former equality-with-input check that also rejected valid canonicalizations like `"8\t0"` → `"80"`.

All 365 WPT cases pass (2 skipped: advanced unicode features Go's regexp engine does not support).