### PR TITLE
refactor!: rename error vars to ErrFoo and expand lint enforcement

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,18 @@
 version: "2"
 
 linters:
+  enable:
+    - err113
+    - goconst
+    - gocritic
+    - intrange
+    - modernize
+    - perfsprint
+    - thelper
+    - unconvert
+    - unparam
+    - wastedassign
+    - whitespace
   settings:
     staticcheck:
       checks:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,6 @@ linters:
     staticcheck:
       checks:
         - "all"
-        # ST1012: public API exports FooError variables (NoBaseURLError,
-        # InvalidPortError, ...). Renaming to ErrFoo would break consumers.
-        - "-ST1012"
         # ST1020/ST1021: exported symbols are documented with their
         # corresponding WHATWG spec URL, not a "Foo does..." sentence.
         # The URL is the most useful pointer for maintainers of a

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -40,7 +40,7 @@ func BenchmarkNew(b *testing.B) {
 			b.ReportAllocs()
 			var p *urlpattern.URLPattern
 			var err error
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				p, err = urlpattern.New(bc.pattern, bc.baseURL, nil)
 				if err != nil {
 					b.Fatal(err)
@@ -60,7 +60,7 @@ func BenchmarkTest(b *testing.B) {
 		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			var ok bool
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				ok = p.Test(bc.input, "")
 			}
 			benchBoolSink = ok
@@ -77,7 +77,7 @@ func BenchmarkExec(b *testing.B) {
 		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			var r *urlpattern.URLPatternResult
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				r = p.Exec(bc.input, "")
 			}
 			benchResultSink = r

--- a/constructor_type_parser.go
+++ b/constructor_type_parser.go
@@ -68,15 +68,13 @@ func parseConstructorString(input string) (*URLPatternInit, error) {
 			if p.state == stateInit {
 				p.rewind()
 
-				if p.isHashPrefix() {
+				switch {
+				case p.isHashPrefix():
 					p.changeState(stateHash, 1)
-				} else if p.isSearchPrefix() {
+				case p.isSearchPrefix():
 					p.changeState(stateSearch, 1)
-					//p.result.Hash = ""
-				} else {
+				default:
 					p.changeState(statePathname, 0)
-					//p.result.Hash = ""
-					//p.result.Search = ""
 				}
 
 				p.tokenIndex += p.tokenIncrement
@@ -160,26 +158,28 @@ func parseConstructorString(input string) (*URLPatternInit, error) {
 			}
 
 		case stateHostname:
-			if p.isIPV6Open() {
+			switch {
+			case p.isIPV6Open():
 				p.hostnameIPv6BracketDepth++
-			} else if p.isIPV6Close() {
+			case p.isIPV6Close():
 				p.hostnameIPv6BracketDepth--
-			} else if p.isPortPrefix() && p.hostnameIPv6BracketDepth == 0 {
+			case p.isPortPrefix() && p.hostnameIPv6BracketDepth == 0:
 				p.changeState(statePort, 1)
-			} else if p.isPathnameStart() {
+			case p.isPathnameStart():
 				p.changeState(statePathname, 0)
-			} else if p.isSearchPrefix() {
+			case p.isSearchPrefix():
 				p.changeState(stateSearch, 1)
-			} else if p.isHashPrefix() {
+			case p.isHashPrefix():
 				p.changeState(stateHash, 1)
 			}
 
 		case statePort:
-			if p.isPathnameStart() {
+			switch {
+			case p.isPathnameStart():
 				p.changeState(statePathname, 0)
-			} else if p.isSearchPrefix() {
+			case p.isSearchPrefix():
 				p.changeState(stateSearch, 1)
-			} else if p.isHashPrefix() {
+			case p.isHashPrefix():
 				p.changeState(stateHash, 1)
 			}
 
@@ -351,7 +351,7 @@ func (p *constructorTypeParser) changeState(newState state, skip int) {
 	}
 
 	p.state = newState
-	p.tokenIndex = p.tokenIndex + skip
+	p.tokenIndex += skip
 	p.componentStart = p.tokenIndex
 	p.tokenIncrement = 0
 }
@@ -359,7 +359,7 @@ func (p *constructorTypeParser) changeState(newState state, skip int) {
 // https://urlpattern.spec.whatwg.org/#make-a-component-string
 func (p *constructorTypeParser) makeComponentString() string {
 	token := p.tokenList[p.tokenIndex]
-	componentStartToken := p.getSafeToken(int(p.componentStart))
+	componentStartToken := p.getSafeToken(p.componentStart)
 	componentStartInputIndex := componentStartToken.index
 	endIndex := token.index
 

--- a/escape.go
+++ b/escape.go
@@ -35,7 +35,7 @@ func init() {
 func escapeRegexpString(s string) string {
 	// A byte loop is correct because all metacharacters are ASCII.
 	var i int
-	for i = 0; i < len(s); i++ {
+	for i = 0; i < len(s); i++ { //nolint:intrange // i is reused below
 		if specialRegexp(s[i]) {
 			break
 		}
@@ -63,7 +63,7 @@ func escapeRegexpString(s string) string {
 func escapePatternString(s string) string {
 	// A byte loop is correct because all metacharacters are ASCII.
 	var i int
-	for i = 0; i < len(s); i++ {
+	for i = 0; i < len(s); i++ { //nolint:intrange // i is reused below
 		if specialPattern(s[i]) {
 			break
 		}

--- a/parser.go
+++ b/parser.go
@@ -47,6 +47,8 @@ var (
 	ErrInvalidPort         = errors.New("invalid port")
 )
 
+var errInvalidHostname = errors.New("invalid hostname")
+
 // https://urlpattern.spec.whatwg.org/#encoding-callback
 type encodingCallback func(string) (string, error)
 
@@ -88,7 +90,7 @@ func parsePatternString(input string, options options, encodingCallback encoding
 			}
 
 			if prefix != "" && prefix != string(options.prefixCodePoint) {
-				p.pendingFixedValue = p.pendingFixedValue + prefix
+				p.pendingFixedValue += prefix
 				prefix = ""
 			}
 
@@ -115,7 +117,7 @@ func parsePatternString(input string, options options, encodingCallback encoding
 			}
 		}
 		if fixedToken != nil {
-			p.pendingFixedValue = p.pendingFixedValue + fixedToken.value
+			p.pendingFixedValue += fixedToken.value
 
 			continue
 		}
@@ -146,7 +148,7 @@ func parsePatternString(input string, options options, encodingCallback encoding
 				return nil, err
 			}
 
-			if _, err := p.consumeRequiredToken(tokenClose); err != nil {
+			if err := p.consumeRequiredToken(tokenClose); err != nil {
 				return nil, fmt.Errorf("missing close token: %w", err)
 			}
 
@@ -166,7 +168,7 @@ func parsePatternString(input string, options options, encodingCallback encoding
 			return nil, err
 		}
 
-		if _, err := p.consumeRequiredToken(tokenEnd); err != nil {
+		if err := p.consumeRequiredToken(tokenEnd); err != nil {
 			return nil, fmt.Errorf("missing end token: %w", err)
 		}
 	}
@@ -265,7 +267,7 @@ func (p *patternParser) addPart(prefix string, nameToken *token, regexpOrWildcar
 	}
 
 	if nameToken == nil && regexpOrWildcardToken == nil && modifier == partModifierNone {
-		p.pendingFixedValue = p.pendingFixedValue + prefix
+		p.pendingFixedValue += prefix
 
 		return nil
 	}
@@ -295,12 +297,13 @@ func (p *patternParser) addPart(prefix string, nameToken *token, regexpOrWildcar
 		return nil
 	}
 
-	regexpValue := ""
-	if regexpOrWildcardToken == nil {
+	var regexpValue string
+	switch {
+	case regexpOrWildcardToken == nil:
 		regexpValue = p.segmentWildcardRegexp
-	} else if regexpOrWildcardToken.tType == tokenAsterisk {
+	case regexpOrWildcardToken.tType == tokenAsterisk:
 		regexpValue = fullWildcardRegexpValue
-	} else {
+	default:
 		regexpValue = regexpOrWildcardToken.value
 	}
 
@@ -312,7 +315,6 @@ func (p *patternParser) addPart(prefix string, nameToken *token, regexpOrWildcar
 	case fullWildcardRegexpValue:
 		pType = partFullWildcard
 		regexpValue = ""
-
 	}
 
 	name := ""
@@ -373,16 +375,16 @@ func (p *patternParser) consumeText() (string, error) {
 }
 
 // https://urlpattern.spec.whatwg.org/#consume-a-required-token
-func (p *patternParser) consumeRequiredToken(tokenType tokenType) (*token, error) {
+func (p *patternParser) consumeRequiredToken(tokenType tokenType) error {
 	result, err := p.tryConsumeToken(tokenType)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if result == nil {
-		return nil, ErrRequiredToken
+		return ErrRequiredToken
 	}
 
-	return result, nil
+	return nil
 }
 
 // https://urlpattern.spec.whatwg.org/#generate-a-segment-wildcard-regexp
@@ -435,7 +437,7 @@ func canonicalizeHostname(hostnameValue, protocolValue string) (string, error) {
 	if hostnameValue[0] != '[' {
 		for _, c := range hostnameValue {
 			if c == ':' {
-				return "", errors.New("invalid hostname")
+				return "", errInvalidHostname
 			}
 		}
 	}
@@ -478,12 +480,13 @@ func canonicalizePort(portValue, protocolValue string) (string, error) {
 	// an ASCII digit (e.g. "invalid80"). Without this the URL library returns
 	// an empty port instead of failing.
 	firstDigit := false
-	for i := 0; i < len(portValue); i++ {
+	for i := range len(portValue) {
 		c := portValue[i]
 		if c == '\t' || c == '\n' || c == '\r' {
 			continue
 		}
 		firstDigit = c >= '0' && c <= '9'
+
 		break
 	}
 	if !firstDigit {

--- a/parser.go
+++ b/parser.go
@@ -39,12 +39,12 @@ var urlParser = url.NewParser()
 var hostnameParser = canonicalizer.New(canonicalizer.WithDefaultScheme("http"))
 
 var (
-	NonEmptySuffixError      = errors.New("suffix must be the empty string")
-	BadParserIndexError      = errors.New("parser's index must be less than parser's token list size")
-	DuplicatePartNameError   = errors.New("duplicate name")
-	RequiredTokenError       = errors.New("missing required token")
-	InvalidIPv6HostnameError = errors.New("invalid IPv6 hostname")
-	InvalidPortError         = errors.New("invalid port")
+	ErrNonEmptySuffix      = errors.New("suffix must be the empty string")
+	ErrBadParserIndex      = errors.New("parser's index must be less than parser's token list size")
+	ErrDuplicatePartName   = errors.New("duplicate name")
+	ErrRequiredToken       = errors.New("missing required token")
+	ErrInvalidIPv6Hostname = errors.New("invalid IPv6 hostname")
+	ErrInvalidPort         = errors.New("invalid port")
 )
 
 // https://urlpattern.spec.whatwg.org/#encoding-callback
@@ -189,7 +189,7 @@ type patternParser struct {
 func (p *patternParser) tryConsumeToken(tokenType tokenType) (*token, error) {
 	// Assert: parser’s index is less than parser’s token list size.
 	if p.index >= len(p.tokenList) {
-		return nil, BadParserIndexError
+		return nil, ErrBadParserIndex
 	}
 
 	nextToken := p.tokenList[p.index]
@@ -277,7 +277,7 @@ func (p *patternParser) addPart(prefix string, nameToken *token, regexpOrWildcar
 	if nameToken == nil && regexpOrWildcardToken == nil {
 		// Assert: suffix is the empty string.
 		if suffix != "" {
-			return NonEmptySuffixError
+			return ErrNonEmptySuffix
 		}
 
 		if prefix == "" {
@@ -325,7 +325,7 @@ func (p *patternParser) addPart(prefix string, nameToken *token, regexpOrWildcar
 
 	// https://urlpattern.spec.whatwg.org/#is-a-duplicate-name
 	if _, seen := p.seenNames[name]; seen {
-		return DuplicatePartNameError
+		return ErrDuplicatePartName
 	}
 
 	encodedPrefix, err := p.encodingCallback(prefix)
@@ -379,7 +379,7 @@ func (p *patternParser) consumeRequiredToken(tokenType tokenType) (*token, error
 		return nil, err
 	}
 	if result == nil {
-		return nil, RequiredTokenError
+		return nil, ErrRequiredToken
 	}
 
 	return result, nil
@@ -487,7 +487,7 @@ func canonicalizePort(portValue, protocolValue string) (string, error) {
 		break
 	}
 	if !firstDigit {
-		return "", InvalidPortError
+		return "", ErrInvalidPort
 	}
 
 	scheme := protocolValue
@@ -595,7 +595,7 @@ func canonicalizeIPv6Hostname(value string) (string, error) {
 
 	for _, c := range value {
 		if c != '[' && c != ']' && c != ':' && !unicode.Is(unicode.ASCII_Hex_Digit, c) {
-			return "", InvalidIPv6HostnameError
+			return "", ErrInvalidIPv6Hostname
 		}
 
 		result.WriteRune(unicode.ToLower(c))

--- a/parts.go
+++ b/parts.go
@@ -20,10 +20,10 @@ const (
 )
 
 var (
-	EmptyPartNameError    = errors.New("part's name must not be empty string")
-	InvalidModifierError  = errors.New(`part's modifier must be "zero-or-more" or "one-or-more"`)
-	InvalidPrefixOrSuffix = errors.New("part's prefix is not the empty string or part's suffix is not the empty string")
-	InvalidPartNameError  = errors.New("part's name is not the empty string or null")
+	ErrEmptyPartName    = errors.New("part's name must not be empty string")
+	ErrInvalidModifier  = errors.New(`part's modifier must be "zero-or-more" or "one-or-more"`)
+	ErrInvalidPrefixOrSuffix = errors.New("part's prefix is not the empty string or part's suffix is not the empty string")
+	ErrInvalidPartName  = errors.New("part's name is not the empty string or null")
 )
 
 type partModifier uint8
@@ -81,7 +81,7 @@ func (pl partList) generateRegularExpressionAndNameList(options options) (string
 
 		// Assert: part's name is not the empty string.
 		if p.name == "" {
-			return "", nil, EmptyPartNameError
+			return "", nil, ErrEmptyPartName
 		}
 
 		nameList = append(nameList, p.name)
@@ -140,12 +140,12 @@ func (pl partList) generateRegularExpressionAndNameList(options options) (string
 
 		// Assert: part’s modifier is "zero-or-more" or "one-or-more".
 		if p.modifier != partModifierZeroOrMore && p.modifier != partModifierOneOrMore {
-			return "", nil, InvalidModifierError
+			return "", nil, ErrInvalidModifier
 		}
 
 		// Assert: part’s prefix is not the empty string or part’s suffix is not the empty string.
 		if p.prefix == "" && p.suffix == "" {
-			return "", nil, InvalidPrefixOrSuffix
+			return "", nil, ErrInvalidPrefixOrSuffix
 		}
 
 		result.WriteString("(?:")
@@ -233,7 +233,7 @@ func (pl partList) generatePatternString(options options) (string, error) {
 
 		// Assert: part’s name is not the empty string or null.
 		if part.name == "" {
-			return "", InvalidPartNameError
+			return "", ErrInvalidPartName
 		}
 
 		if needGrouping {

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/exp/utf8string"
 )
 
-var TypeError = errors.New("type error")
+var ErrType = errors.New("type error")
 
 // https://wicg.github.io/urlpattern/#tokenizing
 type tokenizePolicy bool
@@ -241,7 +241,7 @@ func (t *tokenizer) addTokenWithDefaultPositionAndLength(tType tokenType) {
 
 func (t *tokenizer) processTokenizingError(nextPosition, valuePosition int) error {
 	if t.policy == tokenizePolicyStrict {
-		return fmt.Errorf("%w: %#v", TypeError, t)
+		return fmt.Errorf("%w: %#v", ErrType, t)
 	}
 
 	t.addTokenWithDefaultLength(tokenInvalidChar, nextPosition, valuePosition)

--- a/urlpattern.go
+++ b/urlpattern.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	NoBaseURLError             = errors.New("relative URL and no baseURL provided")
-	UnexpectedEmptyStringError = errors.New("unexpected empty string")
+	ErrNoBaseURL             = errors.New("relative URL and no baseURL provided")
+	ErrUnexpectedEmptyString = errors.New("unexpected empty string")
 )
 
 // https://url.spec.whatwg.org/#special-scheme
@@ -123,7 +123,7 @@ func New(input string, baseURL string, options *Options) (*URLPattern, error) {
 	}
 
 	if baseURL == "" && init.Protocol == nil {
-		return nil, NoBaseURLError
+		return nil, ErrNoBaseURL
 	}
 
 	if baseURL != "" {

--- a/urlpattern.go
+++ b/urlpattern.go
@@ -16,6 +16,12 @@ var (
 	ErrUnexpectedEmptyString = errors.New("unexpected empty string")
 )
 
+// Init-processing mode per https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit.
+const (
+	initTypePattern = "pattern"
+	initTypeURL     = "url"
+)
+
 // https://url.spec.whatwg.org/#special-scheme
 var specialSchemeSet = map[string]struct{}{
 	"ftp":   {},
@@ -139,7 +145,7 @@ func (init *URLPatternInit) New(opt *Options) (*URLPattern, error) {
 		opt = &Options{}
 	}
 
-	processedInit, err := init.process("pattern", nil, nil, nil, nil, nil, nil, nil, nil)
+	processedInit, err := init.process(initTypePattern, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -208,21 +214,16 @@ func (init *URLPatternInit) New(opt *Options) (*URLPattern, error) {
 	protocolMatchesSpecialScheme := urlPattern.protocol.protocolComponentMatchesSpecialScheme()
 
 	hostnameOptions := options{delimiterCodePoint: '.'}
-	if hostnamePatternIsIPv6Address(*processedInit.Hostname) {
+	switch {
+	case hostnamePatternIsIPv6Address(*processedInit.Hostname):
 		urlPattern.hostname, err = compileComponent(*processedInit.Hostname, canonicalizeIPv6Hostname, hostnameOptions)
-		if err != nil {
-			return nil, err
-		}
-	} else if protocolMatchesSpecialScheme || *processedInit.Protocol == "*" {
+	case protocolMatchesSpecialScheme || *processedInit.Protocol == "*":
 		urlPattern.hostname, err = compileComponent(*processedInit.Hostname, canonicalizeDomainName, hostnameOptions)
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	default:
 		urlPattern.hostname, err = compileComponent(*processedInit.Hostname, func(s string) (string, error) { return canonicalizeHostname(s, "") }, hostnameOptions)
-		if err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	urlPattern.port, err = compileComponent(*processedInit.Port, func(s string) (string, error) { return canonicalizePort(s, "") }, defaultOptions)
@@ -276,7 +277,7 @@ func (u *URLPattern) ExecInit(input *URLPatternInit) *URLPatternResult {
 
 	inputs := []*URLPatternInit{input}
 
-	applyResult, err := input.process("url", &protocol, &username, &password, &hostname, &port, &pathname, &search, &hash)
+	applyResult, err := input.process(initTypeURL, &protocol, &username, &password, &hostname, &port, &pathname, &search, &hash)
 	if err != nil {
 		return nil
 	}
@@ -300,15 +301,6 @@ func (u *URLPattern) ExecInit(input *URLPatternInit) *URLPatternResult {
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
 func (u *URLPattern) Exec(input, baseURLString string) *URLPatternResult {
-	protocol := ""
-	username := ""
-	password := ""
-	hostname := ""
-	port := ""
-	pathname := ""
-	search := ""
-	hash := ""
-
 	inputs := []string{input}
 
 	var baseURL *url.Url
@@ -328,16 +320,10 @@ func (u *URLPattern) Exec(input, baseURLString string) *URLPatternResult {
 		return nil
 	}
 
-	protocol = ur.Scheme()
-	username = ur.Username()
-	password = ur.Password()
-	hostname = ur.Hostname()
-	port = ur.Port()
-	pathname = ur.Pathname()
-	search = ur.Query()
-	hash = ur.Fragment()
-
-	r := u.match(protocol, username, password, hostname, port, pathname, search, hash)
+	r := u.match(
+		ur.Scheme(), ur.Username(), ur.Password(), ur.Hostname(),
+		ur.Port(), ur.Pathname(), ur.Query(), ur.Fragment(),
+	)
 	if r != nil {
 		r.Inputs = inputs
 	}
@@ -464,12 +450,12 @@ func (init *URLPatternInit) process(iType string, protocol, username, password, 
 
 		// TODO: the end of this block can be simplified, but let's be as close as possible from the standard algorithm for now
 
-		if iType != "pattern" && init.Protocol == nil && init.Hostname == nil && init.Port == nil && init.Username == nil {
+		if iType != initTypePattern && init.Protocol == nil && init.Hostname == nil && init.Port == nil && init.Username == nil {
 			u := processBaseURLString(baseURL.Username(), iType)
 			result.Username = &u
 		}
 
-		if iType != "pattern" && init.Protocol == nil && init.Hostname == nil && init.Port == nil && init.Username == nil && init.Password == nil {
+		if iType != initTypePattern && init.Protocol == nil && init.Hostname == nil && init.Port == nil && init.Username == nil && init.Password == nil {
 			password := baseURL.Password()
 			p := processBaseURLString(password, iType)
 			result.Password = &p
@@ -599,7 +585,7 @@ func (init *URLPatternInit) process(iType string, protocol, username, password, 
 
 // https://urlpattern.spec.whatwg.org/#process-a-base-url-string
 func processBaseURLString(input, uType string) string {
-	if uType != "pattern" {
+	if uType != initTypePattern {
 		return input
 	}
 
@@ -610,7 +596,7 @@ func processBaseURLString(input, uType string) string {
 func processProtocolForInit(value, pType string) (string, error) {
 	strippedValue := strings.TrimSuffix(value, ":")
 
-	if pType == "pattern" {
+	if pType == initTypePattern {
 		return strippedValue, nil
 	}
 
@@ -619,7 +605,7 @@ func processProtocolForInit(value, pType string) (string, error) {
 
 // https://urlpattern.spec.whatwg.org/#process-username-for-init
 func processUsernameForInit(value, uType string) (string, error) {
-	if uType == "pattern" {
+	if uType == initTypePattern {
 		return value, nil
 	}
 
@@ -628,7 +614,7 @@ func processUsernameForInit(value, uType string) (string, error) {
 
 // https://urlpattern.spec.whatwg.org/#process-password-for-init
 func processPasswordForInit(value, uType string) (string, error) {
-	if uType == "pattern" {
+	if uType == initTypePattern {
 		return value, nil
 	}
 
@@ -637,7 +623,7 @@ func processPasswordForInit(value, uType string) (string, error) {
 
 // https://urlpattern.spec.whatwg.org/#process-hostname-for-init
 func processHostnameForInit(value, protocolValue, uType string) (string, error) {
-	if uType == "pattern" {
+	if uType == initTypePattern {
 		return value, nil
 	}
 
@@ -654,7 +640,7 @@ func processHostnameForInit(value, protocolValue, uType string) (string, error) 
 
 // https://urlpattern.spec.whatwg.org/#process-port-for-init
 func processPortForInit(portValue, protocolValue, pType string) (string, error) {
-	if pType == "pattern" {
+	if pType == initTypePattern {
 		return portValue, nil
 	}
 
@@ -663,7 +649,7 @@ func processPortForInit(portValue, protocolValue, pType string) (string, error) 
 
 // https://urlpattern.spec.whatwg.org/#process-pathname-for-init
 func processPathnameForInit(pathnameValue, protocolValue, ptype string) (string, error) {
-	if ptype == "pattern" {
+	if ptype == initTypePattern {
 		return pathnameValue, nil
 	}
 
@@ -682,7 +668,7 @@ func processPathnameForInit(pathnameValue, protocolValue, ptype string) (string,
 func processSearchForInit(value, sType string) (string, error) {
 	strippedValue := strings.TrimPrefix(value, "?")
 
-	if sType == "pattern" {
+	if sType == initTypePattern {
 		return strippedValue, nil
 	}
 
@@ -693,7 +679,7 @@ func processSearchForInit(value, sType string) (string, error) {
 func processHashForInit(value, hType string) (string, error) {
 	strippedValue := strings.TrimPrefix(value, "#")
 
-	if hType == "pattern" {
+	if hType == initTypePattern {
 		return strippedValue, nil
 	}
 
@@ -710,7 +696,7 @@ func isAbsolutePathname(input, pType string) bool {
 		return true
 	}
 
-	if pType == "url" {
+	if pType == initTypeURL {
 		return false
 	}
 

--- a/urlpattern_test.go
+++ b/urlpattern_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -17,12 +19,17 @@ import (
 
 //go:generate curl https://raw.githubusercontent.com/web-platform-tests/wpt/master/urlpattern/resources/urlpatterntestdata.json -o testdata/urlpatterntestdata.json
 
+var (
+	errInvalidPatternParam = errors.New("invalid constructor parameter")
+	errBaseURLWithInit     = errors.New("invalid second argument: baseURL provided with a URLPatternInit input; use URLPatternInit.BaseURL instead")
+)
+
 type Entry struct {
-	Pattern                []interface{} `json:"pattern"`
-	Inputs                 []interface{} `json:"inputs"`
+	Pattern                []any `json:"pattern"`
+	Inputs                 []any `json:"inputs"`
 	ExactlyEmptyComponents []string      `json:"exactly_empty_components"`
-	ExpectedObj            interface{}   `json:"expected_obj"`
-	ExpectedMatch          interface{}   `json:"expected_match"`
+	ExpectedObj            any   `json:"expected_obj"`
+	ExpectedMatch          any   `json:"expected_match"`
 }
 
 func TestURLPattern(t *testing.T) {
@@ -37,7 +44,7 @@ func TestURLPattern(t *testing.T) {
 	}
 
 	for i, entry := range data {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			pattern, err := newPattern(t, &entry)
 
 			if e, _ := entry.ExpectedObj.(string); e == "error" {
@@ -74,7 +81,7 @@ func TestURLPattern(t *testing.T) {
 			testResult, err := callTest(pattern, entry)
 			if err != nil {
 				if len(entry.Inputs) == 1 {
-					if i, ok := entry.Inputs[0].(map[string]interface{}); ok {
+					if i, ok := entry.Inputs[0].(map[string]any); ok {
 						if p, _ := i["protocol"].(string); p == "café" {
 							t.Skip("TODO: check why this fails, probably a bug in the test suite")
 						}
@@ -89,7 +96,7 @@ func TestURLPattern(t *testing.T) {
 
 			if testResult != expectedTestResult {
 				if len(entry.Pattern) > 0 {
-					e, _ := entry.Pattern[0].(map[string]interface{})
+					e, _ := entry.Pattern[0].(map[string]any)
 					if pa := e["pathname"]; pa != nil {
 						p := pa.(string)
 						if strings.Contains(p, "[") && (strings.Contains(p, "--") || strings.Contains(p, "&&")) {
@@ -117,7 +124,7 @@ func TestURLPattern(t *testing.T) {
 				return
 			}
 
-			expectedObj := entry.ExpectedMatch.(map[string]interface{})
+			expectedObj := entry.ExpectedMatch.(map[string]any)
 			if _, ok := expectedObj["inputs"]; !ok {
 				expectedObj["inputs"] = entry.Inputs
 			}
@@ -131,6 +138,8 @@ func TestURLPattern(t *testing.T) {
 }
 
 func newPattern(t *testing.T, entry *Entry) (*urlpattern.URLPattern, error) {
+	t.Helper()
+
 	var baseURL string
 	options := &urlpattern.Options{}
 
@@ -140,15 +149,15 @@ func newPattern(t *testing.T, entry *Entry) (*urlpattern.URLPattern, error) {
 		return i.New(options)
 
 	case 2:
-		switch entry.Pattern[1].(type) {
-		case map[string]interface{}:
+		switch v := entry.Pattern[1].(type) {
+		case map[string]any:
 			options.IgnoreCase = true
 
 		case string:
-			baseURL = entry.Pattern[1].(string)
+			baseURL = v
 
 		default:
-			return nil, errors.New("invalid constructor parameter #1")
+			return nil, errInvalidPatternParam
 		}
 
 	case 3:
@@ -156,25 +165,22 @@ func newPattern(t *testing.T, entry *Entry) (*urlpattern.URLPattern, error) {
 
 		bu, ok := entry.Pattern[1].(string)
 		if !ok {
-			return nil, errors.New("invalid constructor parameter #2")
+			return nil, errInvalidPatternParam
 		}
 
 		baseURL = bu
 	}
 
-	switch entry.Pattern[0].(type) {
+	switch v := entry.Pattern[0].(type) {
 	case string:
-		return urlpattern.New(entry.Pattern[0].(string), baseURL, options)
+		return urlpattern.New(v, baseURL, options)
 
-	case map[string]interface{}:
+	case map[string]any:
 		if baseURL != "" {
-			return nil, errors.New("Invalid second argument baseURL provided with a URLPatternInit input. Use the URLPatternInit.baseURL property instead.")
+			return nil, errBaseURLWithInit
 		}
 
-		m := entry.Pattern[0].(map[string]interface{})
-		u := initFromObj(m)
-
-		return u.New(options)
+		return initFromObj(v).New(options)
 	}
 
 	t.Fatalf("invalid entry pattern %#v", entry.Pattern)
@@ -183,12 +189,11 @@ func newPattern(t *testing.T, entry *Entry) (*urlpattern.URLPattern, error) {
 }
 
 func newExpectedResult(e Entry) *urlpattern.URLPatternResult {
-
 	expectedResult := urlpattern.URLPatternResult{}
-	for k, v := range e.ExpectedMatch.(map[string]interface{}) {
+	for k, v := range e.ExpectedMatch.(map[string]any) {
 		if k == "inputs" {
-			for _, initInput := range v.([]interface{}) {
-				if ip, ok := initInput.(map[string]interface{}); ok {
+			for _, initInput := range v.([]any) {
+				if ip, ok := initInput.(map[string]any); ok {
 					expectedResult.InitInputs = append(expectedResult.InitInputs, initFromObj(ip))
 				} else {
 					expectedResult.Inputs = append(expectedResult.Inputs, initInput.(string))
@@ -197,15 +202,15 @@ func newExpectedResult(e Entry) *urlpattern.URLPatternResult {
 
 			continue
 		}
-		mv := v.(map[string]interface{})
+		mv := v.(map[string]any)
 		component := urlpattern.URLPatternComponentResult{}
 		component.Input = mv["input"].(string)
-		len := len(mv["groups"].(map[string]interface{}))
+		len := len(mv["groups"].(map[string]any))
 
 		if len > 0 {
 			component.Groups = make(map[string]string, len)
 
-			for k, v := range mv["groups"].(map[string]interface{}) {
+			for k, v := range mv["groups"].(map[string]any) {
 				if v == nil {
 					// TODO: this should probably be nil, but it's currently not implemented
 					component.Groups[k] = ""
@@ -246,7 +251,7 @@ func newExpectedResult(e Entry) *urlpattern.URLPatternResult {
 	return &expectedResult
 }
 
-func stringOrNil(v interface{}) *string {
+func stringOrNil(v any) *string {
 	if v == nil {
 		return nil
 	}
@@ -271,10 +276,10 @@ func callTest(pattern *urlpattern.URLPattern, entry Entry) (bool, error) {
 	}
 
 	if len(entry.Inputs) > 1 {
-		return false, errors.New("invalid constructor parameter #1")
+		return false, errInvalidPatternParam
 	}
 
-	return pattern.TestInit(initFromObj(entry.Inputs[0].(map[string]interface{}))), nil
+	return pattern.TestInit(initFromObj(entry.Inputs[0].(map[string]any))), nil
 }
 
 func callExec(pattern *urlpattern.URLPattern, entry Entry) (*urlpattern.URLPatternResult, error) {
@@ -292,13 +297,13 @@ func callExec(pattern *urlpattern.URLPattern, entry Entry) (*urlpattern.URLPatte
 	}
 
 	if len(entry.Inputs) > 1 {
-		return nil, errors.New("invalid constructor parameter #1")
+		return nil, errInvalidPatternParam
 	}
 
-	return pattern.ExecInit(initFromObj(entry.Inputs[0].(map[string]interface{}))), nil
+	return pattern.ExecInit(initFromObj(entry.Inputs[0].(map[string]any))), nil
 }
 
-func initFromObj(m map[string]interface{}) *urlpattern.URLPatternInit {
+func initFromObj(m map[string]any) *urlpattern.URLPatternInit {
 	return &urlpattern.URLPatternInit{
 		Protocol: stringOrNil(m["protocol"]),
 		Username: stringOrNil(m["username"]),
@@ -322,17 +327,15 @@ var earlierComponents = map[string][]string{
 
 func buildExpected(entry Entry, component string) *string {
 	if entry.ExpectedObj == nil {
-		for _, c := range entry.ExactlyEmptyComponents {
-			if c == component {
-				es := ""
-				return &es
-			}
+		if slices.Contains(entry.ExactlyEmptyComponents, component) {
+			es := ""
+			return &es
 		}
 
 		if len(entry.Pattern) > 0 {
 			star := "*"
 
-			p, ok := entry.Pattern[0].(map[string]interface{})
+			p, ok := entry.Pattern[0].(map[string]any)
 			if ok {
 				if p[component] != nil {
 					v := p[component].(string)
@@ -383,13 +386,12 @@ func buildExpected(entry Entry, component string) *string {
 
 				return &star
 			}
-
 		}
 
 		return nil
 	}
 
-	o := entry.ExpectedObj.(map[string]interface{})
+	o := entry.ExpectedObj.(map[string]any)
 	e, ok := o[component]
 	if !ok {
 		return nil
@@ -401,6 +403,8 @@ func buildExpected(entry Entry, component string) *string {
 }
 
 func assertExpectedObject(t *testing.T, entry Entry, pattern *urlpattern.URLPattern) {
+	t.Helper()
+
 	assertExpectedObjectProp(t, "protocol", entry, pattern.Protocol())
 	assertExpectedObjectProp(t, "username", entry, pattern.Username())
 	assertExpectedObjectProp(t, "password", entry, pattern.Password())
@@ -409,10 +413,11 @@ func assertExpectedObject(t *testing.T, entry Entry, pattern *urlpattern.URLPatt
 	assertExpectedObjectProp(t, "pathname", entry, pattern.Pathname())
 	assertExpectedObjectProp(t, "search", entry, pattern.Search())
 	assertExpectedObjectProp(t, "hash", entry, pattern.Hash())
-
 }
 
 func assertExpectedObjectProp(t *testing.T, key string, entry Entry, value string) {
+	t.Helper()
+
 	expected := buildExpected(entry, key)
 	if expected == nil {
 		return


### PR DESCRIPTION
## Summary
Two commits:

1. **`refactor!`**: rename the 13 exported `FooError` vars to idiomatic `ErrFoo` to satisfy staticcheck ST1012. Breaking change — consumers referencing these by name must update imports (full rename table in the commit body).

2. **`chore`**: expand `.golangci.yml` with `err113`, `goconst`, `gocritic`, `intrange`, `modernize`, `perfsprint`, `thelper`, `unconvert`, `unparam`, `wastedassign`, `whitespace`. Address every finding:
   - collapse `ExecInit`'s 8 dead `var = \"\"` initializations;
   - `x += y`, switch-on-type, if-else → switch refactors;
   - `for range b.N` / `for i := range n` idioms;
   - `interface{}` → `any`, `slices.Contains`, `strconv.Itoa`;
   - drop redundant `int()` conversion;
   - `consumeRequiredToken` drops its unused `*token` return;
   - hoist `\"invalid hostname\"` to a package sentinel;
   - extract `\"pattern\"` / `\"url\"` to `initTypePattern` / `initTypeURL` constants;
   - `t.Helper()` in the three WPT helpers;
   - remove dead commented `//p.result.Hash = \"\"` / `//p.result.Search = \"\"` lines and collapse the surrounding if-else into a switch.

Opinionated linters (`wsl`, `wsl_v5`, `lll`, `varnamelen`, `exhaustruct`, `gochecknoglobals`, `nlreturn`, `mnd`, `cyclop`, `gocognit`, `nestif`, `funcorder`, `paralleltest`, `noinlineerr`, `wrapcheck`, `forcetypeassert`, `tagliatelle`, `exhaustive`) stay disabled — they'd require structural refactors or change error identities exposed to consumers.

`go test -race ./...` and `golangci-lint run` both clean against the widened configuration.