### PR TITLE
perf: share precompiled regexps for common component patterns

### DIFF
--- a/constructor_type_parser.go
+++ b/constructor_type_parser.go
@@ -421,6 +421,18 @@ func (p *constructorTypeParser) isIPV6Close() bool {
 	return p.isNonSpecialPatternChar(p.tokenIndex, "]")
 }
 
+// Precompiled regular expressions for the component patterns that recur across
+// nearly every URLPattern: the full wildcard (the default for username,
+// password, search and hash) and the empty component (a common port). Compiled
+// once at init; a *regexp.Regexp is safe for concurrent use, so the same
+// instance is shared by every component whose generated expression matches.
+var sharedComponentRegexps = map[string]*regexp.Regexp{ //nolint:gochecknoglobals
+	`\A(?:(.*))\z`:     regexp.MustCompile(`\A(?:(.*))\z`),
+	`(?i)\A(?:(.*))\z`: regexp.MustCompile(`(?i)\A(?:(.*))\z`),
+	`\A(?:)\z`:         regexp.MustCompile(`\A(?:)\z`),
+	`(?i)\A(?:)\z`:     regexp.MustCompile(`(?i)\A(?:)\z`),
+}
+
 // https://urlpattern.spec.whatwg.org/#compile-a-component
 func compileComponent(input string, encodencodingCallback encodingCallback, options options) (*component, error) {
 	partList, err := parsePatternString(input, options, encodencodingCallback)
@@ -434,9 +446,19 @@ func compileComponent(input string, encodencodingCallback encodingCallback, opti
 		return nil, err
 	}
 
-	regularExpression, err := regexp.Compile(regularExpressionString)
-	if err != nil {
-		return nil, err
+	// Most components of a typical pattern are the full wildcard or empty:
+	// username, password, search and hash default to the full wildcard and the
+	// port is often empty. Their generated regular expressions are a tiny fixed
+	// set of constant strings, so reuse a shared precompiled *regexp.Regexp
+	// (safe for concurrent use) instead of paying regexp.Compile per component.
+	regularExpression, ok := sharedComponentRegexps[regularExpressionString]
+	if !ok {
+		var err error
+
+		regularExpression, err = regexp.Compile(regularExpressionString)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	patternString, err := partList.generatePatternString(options)


### PR DESCRIPTION
## What

`compileComponent` calls `regexp.Compile` once per URL component (protocol, username, password, hostname, port, pathname, search, hash). In typical patterns most components are either the full wildcard (`\A(?:(.*))\z` — the default for username, password, search and hash) or empty (`\A(?:)\z` — a common port). Their generated regular expressions are a tiny fixed set of constant strings.

This reuses a shared, precompiled `*regexp.Regexp` for those recurring expressions (a `*regexp.Regexp` is safe for concurrent use), falling back to `regexp.Compile` for everything else. Both the case-sensitive and `(?i)` case-insensitive forms are covered. Behavior is unchanged; the full existing test suite passes.

## Why

For `https://example.com/books/:id`, 5 of the 8 component regexps are one of those two constant strings, so ~62% of the per-pattern `regexp.Compile` calls were redundant.

## Benchmark

`go test -bench BenchmarkNew -benchmem -count=8`, benchstat, Apple M5 Pro:

| pattern | time | B/op | allocs/op |
|---|---|---|---|
| simple | -24.6% | -29.5% | -25.4% |
| wildcard | -24.5% | -28.1% | -26.2% |
| named | -22.5% | -26.1% | -22.5% |
| regex | -24.8% | -29.7% | -24.9% |
| full | -8.2% | -9.3% | -7.4% |
| **geomean** | **-21.2%** | **-24.9%** | **-21.6%** |

The `full` pattern (every component populated, few wildcards) gains least, as expected.