### PR TITLE
fix: resolve goconst lint failures in test files

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,10 +6,12 @@ import (
 	"github.com/dunglas/go-urlpattern"
 )
 
+const benchExampleURL = "https://example.com/foo/bar"
+
 var benchmarkPatterns = []struct {
 	name, pattern, baseURL string
 }{
-	{"simple", "https://example.com/foo/bar", ""},
+	{"simple", benchExampleURL, ""},
 	{"wildcard", "https://*.example.com/*", ""},
 	{"named", "https://example.com/users/:id/posts/:postId", ""},
 	{"regex", "https://example.com/items/(\\d+)", ""},
@@ -19,7 +21,7 @@ var benchmarkPatterns = []struct {
 var benchmarkMatches = []struct {
 	name, pattern, input string
 }{
-	{"simple", "https://example.com/foo/bar", "https://example.com/foo/bar"},
+	{"simple", benchExampleURL, benchExampleURL},
 	{"wildcard", "https://*.example.com/*", "https://api.example.com/users/42"},
 	{"named", "https://example.com/users/:id/posts/:postId", "https://example.com/users/42/posts/7"},
 	{"regex", "https://example.com/items/(\\d+)", "https://example.com/items/12345"},

--- a/parts.go
+++ b/parts.go
@@ -20,10 +20,10 @@ const (
 )
 
 var (
-	ErrEmptyPartName    = errors.New("part's name must not be empty string")
-	ErrInvalidModifier  = errors.New(`part's modifier must be "zero-or-more" or "one-or-more"`)
+	ErrEmptyPartName         = errors.New("part's name must not be empty string")
+	ErrInvalidModifier       = errors.New(`part's modifier must be "zero-or-more" or "one-or-more"`)
 	ErrInvalidPrefixOrSuffix = errors.New("part's prefix is not the empty string or part's suffix is not the empty string")
-	ErrInvalidPartName  = errors.New("part's name is not the empty string or null")
+	ErrInvalidPartName       = errors.New("part's name is not the empty string or null")
 )
 
 type partModifier uint8

--- a/urlpattern_test.go
+++ b/urlpattern_test.go
@@ -24,6 +24,15 @@ var (
 	errBaseURLWithInit     = errors.New("invalid second argument: baseURL provided with a URLPatternInit input; use URLPatternInit.BaseURL instead")
 )
 
+const (
+	componentProtocol = "protocol"
+	componentHostname = "hostname"
+	componentPort     = "port"
+	componentPathname = "pathname"
+	componentSearch   = "search"
+	componentHash     = "hash"
+)
+
 type Entry struct {
 	Pattern                []any `json:"pattern"`
 	Inputs                 []any `json:"inputs"`
@@ -82,7 +91,7 @@ func TestURLPattern(t *testing.T) {
 			if err != nil {
 				if len(entry.Inputs) == 1 {
 					if i, ok := entry.Inputs[0].(map[string]any); ok {
-						if p, _ := i["protocol"].(string); p == "café" {
+						if p, _ := i[componentProtocol].(string); p == "café" {
 							t.Skip("TODO: check why this fails, probably a bug in the test suite")
 						}
 					}
@@ -97,7 +106,7 @@ func TestURLPattern(t *testing.T) {
 			if testResult != expectedTestResult {
 				if len(entry.Pattern) > 0 {
 					e, _ := entry.Pattern[0].(map[string]any)
-					if pa := e["pathname"]; pa != nil {
+					if pa := e[componentPathname]; pa != nil {
 						p := pa.(string)
 						if strings.Contains(p, "[") && (strings.Contains(p, "--") || strings.Contains(p, "&&")) {
 							t.Skip("Advanced unicode features aren't supported by Go")
@@ -222,7 +231,7 @@ func newExpectedResult(e Entry) *urlpattern.URLPatternResult {
 		}
 
 		switch k {
-		case "protocol":
+		case componentProtocol:
 			expectedResult.Protocol = component
 
 		case "username":
@@ -231,19 +240,19 @@ func newExpectedResult(e Entry) *urlpattern.URLPatternResult {
 		case "password":
 			expectedResult.Password = component
 
-		case "hostname":
+		case componentHostname:
 			expectedResult.Hostname = component
 
-		case "port":
+		case componentPort:
 			expectedResult.Port = component
 
-		case "pathname":
+		case componentPathname:
 			expectedResult.Pathname = component
 
-		case "search":
+		case componentSearch:
 			expectedResult.Search = component
 
-		case "hash":
+		case componentHash:
 			expectedResult.Hash = component
 		}
 	}
@@ -305,24 +314,24 @@ func callExec(pattern *urlpattern.URLPattern, entry Entry) (*urlpattern.URLPatte
 
 func initFromObj(m map[string]any) *urlpattern.URLPatternInit {
 	return &urlpattern.URLPatternInit{
-		Protocol: stringOrNil(m["protocol"]),
+		Protocol: stringOrNil(m[componentProtocol]),
 		Username: stringOrNil(m["username"]),
 		Password: stringOrNil(m["password"]),
-		Hostname: stringOrNil(m["hostname"]),
-		Port:     stringOrNil(m["port"]),
-		Pathname: stringOrNil(m["pathname"]),
-		Search:   stringOrNil(m["search"]),
-		Hash:     stringOrNil(m["hash"]),
+		Hostname: stringOrNil(m[componentHostname]),
+		Port:     stringOrNil(m[componentPort]),
+		Pathname: stringOrNil(m[componentPathname]),
+		Search:   stringOrNil(m[componentSearch]),
+		Hash:     stringOrNil(m[componentHash]),
 		BaseURL:  stringOrNil(m["baseURL"]),
 	}
 }
 
 var earlierComponents = map[string][]string{
-	"hostname": {"protocol"},
-	"port":     {"protocol", "hostname"},
-	"pathname": {"protocol", "hostname", "port"},
-	"search":   {"protocol", "hostname", "port", "pathname"},
-	"hash":     {"protocol", "hostname", "port", "pathname", "search"},
+	componentHostname: {componentProtocol},
+	componentPort:     {componentProtocol, componentHostname},
+	componentPathname: {componentProtocol, componentHostname, componentPort},
+	componentSearch:   {componentProtocol, componentHostname, componentPort, componentPathname},
+	componentHash:     {componentProtocol, componentHostname, componentPort, componentPathname, componentSearch},
 }
 
 func buildExpected(entry Entry, component string) *string {
@@ -361,23 +370,23 @@ func buildExpected(entry Entry, component string) *string {
 				if baseURL != nil && component != "username" && component != "password" {
 					var baseValue string
 					switch component {
-					case "protocol":
+					case componentProtocol:
 						baseValue = baseURL.Protocol()
 						baseValue = baseValue[:len(baseValue)-1]
 
-					case "hostname":
+					case componentHostname:
 						baseValue = baseURL.Hostname()
 
-					case "port":
+					case componentPort:
 						baseValue = baseURL.Port()
 
-					case "pathname":
+					case componentPathname:
 						baseValue = baseURL.Pathname()
 
-					case "search":
+					case componentSearch:
 						baseValue = baseURL.Search()[1:]
 
-					case "hash":
+					case componentHash:
 						baseValue = baseURL.Hash()[1:]
 					}
 
@@ -405,14 +414,14 @@ func buildExpected(entry Entry, component string) *string {
 func assertExpectedObject(t *testing.T, entry Entry, pattern *urlpattern.URLPattern) {
 	t.Helper()
 
-	assertExpectedObjectProp(t, "protocol", entry, pattern.Protocol())
+	assertExpectedObjectProp(t, componentProtocol, entry, pattern.Protocol())
 	assertExpectedObjectProp(t, "username", entry, pattern.Username())
 	assertExpectedObjectProp(t, "password", entry, pattern.Password())
-	assertExpectedObjectProp(t, "hostname", entry, pattern.Hostname())
-	assertExpectedObjectProp(t, "port", entry, pattern.Port())
-	assertExpectedObjectProp(t, "pathname", entry, pattern.Pathname())
-	assertExpectedObjectProp(t, "search", entry, pattern.Search())
-	assertExpectedObjectProp(t, "hash", entry, pattern.Hash())
+	assertExpectedObjectProp(t, componentHostname, entry, pattern.Hostname())
+	assertExpectedObjectProp(t, componentPort, entry, pattern.Port())
+	assertExpectedObjectProp(t, componentPathname, entry, pattern.Pathname())
+	assertExpectedObjectProp(t, componentSearch, entry, pattern.Search())
+	assertExpectedObjectProp(t, componentHash, entry, pattern.Hash())
 }
 
 func assertExpectedObjectProp(t *testing.T, key string, entry Entry, value string) {

--- a/urlpattern_test.go
+++ b/urlpattern_test.go
@@ -34,11 +34,11 @@ const (
 )
 
 type Entry struct {
-	Pattern                []any `json:"pattern"`
-	Inputs                 []any `json:"inputs"`
-	ExactlyEmptyComponents []string      `json:"exactly_empty_components"`
-	ExpectedObj            any   `json:"expected_obj"`
-	ExpectedMatch          any   `json:"expected_match"`
+	Pattern                []any    `json:"pattern"`
+	Inputs                 []any    `json:"inputs"`
+	ExactlyEmptyComponents []string `json:"exactly_empty_components"`
+	ExpectedObj            any      `json:"expected_obj"`
+	ExpectedMatch          any      `json:"expected_match"`
 }
 
 func TestURLPattern(t *testing.T) {


### PR DESCRIPTION
## Summary

CI on `main` is currently failing on the `Lint` job: `golangci-lint`'s `goconst` check flags 7 string literals repeated 3+ times.

- `benchmark_test.go`: the example URL `https://example.com/foo/bar` is repeated across two benchmark tables.
- `urlpattern_test.go`: the URL component names (`protocol`, `hostname`, `port`, `pathname`, `search`, `hash`) recur across map lookups, `switch` cases, and helper calls.

This PR extracts those literals into named constants (`benchExampleURL` and `componentProtocol`/`componentHostname`/`componentPort`/`componentPathname`/`componentSearch`/`componentHash`) and replaces every occurrence. Pure test refactor, no behavior change.